### PR TITLE
Use Discovery API for Wallets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+VITE_DISCOVERY_API=https://fcl-discovery.onflow.org/api/testnet/authn
+VITE_ACCESS_NODE_API=https://rest-testnet.onflow.org
+VITE_BLOCTO_DISCOVERY=https://flow-wallet-testnet.blocto.app/authn
+VITE_DAPPER_DISCOVERY=https://staging.accounts.meetdapper.com/fcl/authn-restricted
+VITE_FCL_DISCOVERY=https://fcl-discovery.onflow.org/testnet/authn
+VITE_GRAFFLE_MAINNET_PROJECT_ID=
+VITE_GRAFFLE_MAINNET_API_KEY=
+VITE_GRAFFLE_MAINNET_API_URL=
+VITE_FLOAT_ADDRESS=
+VITE_CORE_ADDRESS=
+VITE_FLOWTOKEN_ADDRESS=
+VITE_FUNGIBLETOKEN_ADDRESS=
+VITE_SECRET_SALT=

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,11 @@ node_modules
 /.svelte-kit
 /package
 .env
+.env.local
 .env.production
 .env.development
 .env.local
 .vercel
 .output
 flow.json
-.env.development
-.env.production
 .vercel_build_output

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .env
 .env.production
 .env.development
+.env.local
 .vercel
 .output
 flow.json

--- a/src/lib/components/WalletModal.svelte
+++ b/src/lib/components/WalletModal.svelte
@@ -1,6 +1,25 @@
 <script>
   import { configureFCLAndLogin } from "$lib/flow/actions";
+  import * as fcl from "@onflow/fcl";
   import { walletModal } from "$lib/stores";
+  import { onMount } from 'svelte';
+	
+  let services = [];
+  export let _ = s => s.toLowerCase();
+
+  onMount(async () => {
+    try {
+      const response = await fcl.discovery.authn.snapshot()
+      if (response) {
+        services = response.results;
+      } else {
+        throw new Error("Error fetching services");
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
 </script>
 
 <article>
@@ -25,18 +44,14 @@
       <span>Connect Dapper</span>
     </button>
   </div>
-  <div class="wallet">
-    <button id="blocto" on:click={() => configureFCLAndLogin("blocto")}>
-      <img src="/blocto-logo.jpg" alt="blocto logo" />
-      <span>Connect Blocto</span>
-    </button>
-  </div>
-  <div class="wallet">
-    <button id="lilico" on:click={() => configureFCLAndLogin("lilico")}>
-      <img src="/lilico-logo.jpg" alt="lilico logo" />
-      <span>Connect Lilico</span>
-    </button>
-  </div>
+  {#each services as service}
+    <div class="wallet">
+      <button id={_(service.provider.name)} on:click={() => configureFCLAndLogin(_(service.provider.name), service)}>
+        <img src={`${_(service.provider.name)}-logo.jpg`} alt={`${_(service.provider.name)} logo`} />
+        <span>Connect {service.provider.name}</span>
+      </button>
+    </div>
+  {/each}
 </article>
 
 <style>

--- a/src/lib/flow/actions.js
+++ b/src/lib/flow/actions.js
@@ -78,7 +78,7 @@ const configureFCL = (wallet) => {
   }
 }
 
-export const configureFCLAndLogin = async (wallet) => {
+export const configureFCLAndLogin = async (wallet, service) => {
   currentWallet.set(wallet);
   configureFCL(wallet);
   await fcl.authenticate();

--- a/src/lib/flow/config.js
+++ b/src/lib/flow/config.js
@@ -4,13 +4,14 @@ config({
   "app.detail.title": "FLOAT", // Shows user what dapp is trying to connect
   "app.detail.icon": "https://floats.city/floatlogo_big.png", // shows image to the user to display your dapp brand
   "accessNode.api": import.meta.env.VITE_ACCESS_NODE_API, // import.meta.env.VITE_ACCESS_NODE_API,
+  "discovery.authn.endpoint": import.meta.env.VITE_DISCOVERY_API, // Mainnet: "https://fcl-discovery.onflow.org/api/authn"
   "0xFLOAT": import.meta.env.VITE_FLOAT_ADDRESS,
   "0xCORE": import.meta.env.VITE_CORE_ADDRESS,
   "0xFLOWTOKEN": import.meta.env.VITE_FLOWTOKEN_ADDRESS,
   "0xFUNGIBLETOKEN": import.meta.env.VITE_FUNGIBLETOKEN_ADDRESS,
   "0xFN": "0x233eb012d34b0070",
   "0xFIND": "0x097bafa4e0b48eef",
-  "0xFLOWSTORAGEFEES": "0xe467b9dd11fa00df"
+  "0xFLOWSTORAGEFEES": "0xe467b9dd11fa00df",
 })
 
 export const verifiersIdentifier = 'A.2d4c3caffbeab845';


### PR DESCRIPTION
### Use Discovery API to fetch and display available wallets

This PR changes hard coding of wallets to use the Discovery API.

- Fetch available wallets from discovery on mount of WalletModal
- Display details based on service data

**TODO**
Future updates to improve
- Once Dapper Wallet is added to Discovery, hard coding of details can be removed and replaced with API response
- Lilico update will allow for opening directly vs using current Discovery iFrame strategy
- `configureFCLAndLogin` can be replaced with direct calls to `fcl.authenticate({ service })` once above criteria are met
- Wallet logos should be URI based in service defs from Discovery API
